### PR TITLE
2021-06-14 GUARD-1895 Square: Deduct Quantity For POS Sales

### DIFF
--- a/src/SquareAccess/Models/Order.cs
+++ b/src/SquareAccess/Models/Order.cs
@@ -27,7 +27,7 @@ namespace SquareAccess.Models
 	public static class OrderExtensions
 	{
 		public static SquareOrder ToSvOrder( this Order order, IEnumerable< SquareItem > orderCatalogObjects )
-		{
+		{			
 			return new SquareOrder
 			{
 				OrderId = order.Id,
@@ -40,7 +40,7 @@ namespace SquareAccess.Models
 				Recipient = order.Fulfillments?.ToSvRecipient() ?? new SquareOrderRecipient(),
 				Discounts = order.Discounts?.ToSvDiscounts().ToList(),
 				TotalTax = order.TotalTaxMoney?.ToNMoney(),
-				SourceName = order.Source != null && order.Source.Name == "Square Online" ? SquareSourceNameEnum.web : SquareSourceNameEnum.pos,
+				SourceName = !string.IsNullOrEmpty( order.CustomerId ) ? SquareSourceNameEnum.web : SquareSourceNameEnum.pos,
 				LocationId = order.LocationId
 			};
 		}

--- a/src/SquareAccess/Models/Order.cs
+++ b/src/SquareAccess/Models/Order.cs
@@ -13,13 +13,15 @@ namespace SquareAccess.Models
 		public string OrderId { get; set; }
 		public string ReceiptId { get; set; }
 		public Money? OrderTotal { get; set; }
-		public string CheckoutStatus { get; set; }
+		public string CheckoutStatus { get; set; }				
 		public DateTime CreateDateUtc { get; set; }
 		public DateTime UpdateDateUtc { get; set; }
 		public IEnumerable< SquareOrderLineItem > LineItems { get; set; }
 		public SquareOrderRecipient Recipient { get; set; }
 		public Money? TotalTax { get; set; }
 		public List< SquareOrderDiscount > Discounts { get; set; }
+		public SquareSourceNameEnum SourceName { get; set; }		
+		public string LocationId { get; set; }
 	}
 
 	public static class OrderExtensions
@@ -37,7 +39,9 @@ namespace SquareAccess.Models
 				LineItems = order.LineItems?.ToSvOrderLineItems( orderCatalogObjects ).ToList(),
 				Recipient = order.Fulfillments?.ToSvRecipient() ?? new SquareOrderRecipient(),
 				Discounts = order.Discounts?.ToSvDiscounts().ToList(),
-				TotalTax = order.TotalTaxMoney?.ToNMoney()
+				TotalTax = order.TotalTaxMoney?.ToNMoney(),
+				SourceName = order.Source != null && order.Source.Name == "Square Online" ? SquareSourceNameEnum.web : SquareSourceNameEnum.pos,
+				LocationId = order.LocationId
 			};
 		}
 
@@ -56,5 +60,11 @@ namespace SquareAccess.Models
 		public const string Completed = "COMPLETED";
 		public const string Open = "OPEN";
 		public const string Cancelled = "CANCELED";
+	}
+	
+	public enum SquareSourceNameEnum
+	{				
+		web,
+		pos
 	}
 }

--- a/src/SquareAccess/Models/Order.cs
+++ b/src/SquareAccess/Models/Order.cs
@@ -40,7 +40,7 @@ namespace SquareAccess.Models
 				Recipient = order.Fulfillments?.ToSvRecipient() ?? new SquareOrderRecipient(),
 				Discounts = order.Discounts?.ToSvDiscounts().ToList(),
 				TotalTax = order.TotalTaxMoney?.ToNMoney(),
-				SourceName = !string.IsNullOrEmpty( order.CustomerId ) ? SquareSourceNameEnum.web : SquareSourceNameEnum.pos,
+				SourceName = !string.IsNullOrEmpty( order.CustomerId ) ? SquareSourceNameEnum.Web : SquareSourceNameEnum.Pos,
 				LocationId = order.LocationId
 			};
 		}
@@ -64,7 +64,7 @@ namespace SquareAccess.Models
 	
 	public enum SquareSourceNameEnum
 	{				
-		web,
-		pos
+		Web,
+		Pos
 	}
 }

--- a/src/SquareAccess/SquareAccess.csproj
+++ b/src/SquareAccess/SquareAccess.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Authors>SkuVault</Authors>
     <Company>SkuVault</Company>
-    <Version>1.1.10.0-alpha</Version>
+    <Version>1.1.10.0</Version>
     <Description>SquareAccess webservices API wrapper</Description>
     <Copyright>SkuVault © 2019-2021</Copyright>
     <PackageLicenseUrl>https://github.com/skuvault/squareAccess/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/SquareAccess/SquareAccess.csproj
+++ b/src/SquareAccess/SquareAccess.csproj
@@ -4,15 +4,15 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Authors>SkuVault</Authors>
     <Company>SkuVault</Company>
-    <Version>1.1.9.0</Version>
+    <Version>1.1.10.0-alpha</Version>
     <Description>SquareAccess webservices API wrapper</Description>
-    <Copyright>SkuVault © 2019</Copyright>
+    <Copyright>SkuVault © 2019-2021</Copyright>
     <PackageLicenseUrl>https://github.com/skuvault/squareAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/squareAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/squareAccess</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.1.9.0</AssemblyVersion>
-    <FileVersion>1.1.9.0</FileVersion>
+    <AssemblyVersion>1.1.10.0</AssemblyVersion>
+    <FileVersion>1.1.10.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SquareAccessTests/OrdersServiceTests.cs
+++ b/src/SquareAccessTests/OrdersServiceTests.cs
@@ -18,7 +18,9 @@ namespace SquareAccessTests
 	{
 		private ISquareOrdersService _ordersService;
 		private bool _firstPage;
-		private const string TestLocationId = "8Q9RHBKTRDAG8";
+		private const string TestLocationId = "1GZS83Z3FC3Y3";
+		private readonly DateTime startDateUtc = DateTime.UtcNow.AddDays(-7);
+		private readonly DateTime endDateUtc = DateTime.UtcNow;		
 
 		[ SetUp ]
 		public void Init()
@@ -28,10 +30,7 @@ namespace SquareAccessTests
 
 		[ Test ]
 		public void GetOrdersAsync()
-		{
-			var startDateUtc = new DateTime( 1971, 1, 1 );
-			var endDateUtc = DateTime.MaxValue;
-
+		{						
 			var result = _ordersService.GetOrdersAsync( startDateUtc, endDateUtc, CancellationToken.None ).Result;
 
 			result.Should().NotBeEmpty();
@@ -39,9 +38,7 @@ namespace SquareAccessTests
 
 		[ Test ]
 		public void GetOrdersAsync_ByPage()
-		{
-			var startDateUtc = new DateTime( 1971, 1, 1 );
-			var endDateUtc = DateTime.MaxValue;
+		{			
 			this.Config.OrdersPageSize = 2;
 
 			var result = _ordersService.GetOrdersAsync( startDateUtc, endDateUtc, CancellationToken.None ).Result;
@@ -51,9 +48,7 @@ namespace SquareAccessTests
 
 		[ Test ]
 		public void CreateSearchOrdersBody()
-		{
-			var startDateUtc = new DateTime( 1971, 1, 1 );
-			var endDateUtc = DateTime.MaxValue;
+		{						
 			var locations = new List< SquareLocation >
 			{
 				new SquareLocation
@@ -79,9 +74,7 @@ namespace SquareAccessTests
 
 		[ Test ]
 		public void CollectOrdersFromAllPagesAsync()
-		{
-			var startDateUtc = new DateTime( 1971, 1, 1 );
-			var endDateUtc = DateTime.MaxValue;
+		{			
 			const int ordersPerPage = 2;
 			_firstPage = true;
 			const string catalogObjectId = "asldfjlkj";

--- a/src/SquareAccessTests/OrdersServiceTests.cs
+++ b/src/SquareAccessTests/OrdersServiceTests.cs
@@ -19,7 +19,7 @@ namespace SquareAccessTests
 		private ISquareOrdersService _ordersService;
 		private bool _firstPage;
 		private const string TestLocationId = "1GZS83Z3FC3Y3";
-		private readonly DateTime startDateUtc = DateTime.UtcNow.AddDays(-7);
+		private readonly DateTime startDateUtc = DateTime.UtcNow.AddDays(-20);
 		private readonly DateTime endDateUtc = DateTime.UtcNow;		
 
 		[ SetUp ]


### PR DESCRIPTION
Added LocationId and SourceName (POS or Online) fields - this can be determined by the presence / absence of the customer_id in the order object. Please see the [link](https://developer.squareup.com/forums/t/customer-id-field-locations-from-an-order/2030/2)  
