### PR TITLE
guard/PBL-9319-update-square-search-orders-location-ids-api

### DIFF
--- a/src/SquareAccess/Services/Orders/SquareOrdersService.cs
+++ b/src/SquareAccess/Services/Orders/SquareOrdersService.cs
@@ -15,208 +15,228 @@ using SquareAccess.Shared;
 
 namespace SquareAccess.Services.Orders
 {
-	public sealed class SquareOrdersService : AuthorizedBaseService, ISquareOrdersService
-	{
-		private readonly ISquareLocationsService _locationsService;
-		private readonly ISquareItemsService _itemsService;
-		private readonly OrdersApi _ordersApi;
-		private const int MaxLocationBatchSize = 10;
-		public delegate Task< SquareOrdersBatch > GetOrdersWithRelatedDataAsyncDelegate( SearchOrdersRequest requestBody );
+    public sealed class SquareOrdersService : AuthorizedBaseService, ISquareOrdersService
+    {
+        private readonly ISquareLocationsService _locationsService;
+        private readonly ISquareItemsService _itemsService;
+        private readonly OrdersApi _ordersApi;
+        private const int MaxLocationBatchSize = 10;
 
-		public SquareOrdersService( SquareConfig config, SquareMerchantCredentials credentials, ISquareLocationsService locationsService, ISquareItemsService itemsService ) : base( config, credentials )
-		{
-			Condition.Requires( locationsService, "locationsService" ).IsNotNull();
-			Condition.Requires( itemsService, "itemsService" ).IsNotNull();
+        public delegate Task<SquareOrdersBatch> GetOrdersWithRelatedDataAsyncDelegate(SearchOrdersRequest requestBody);
 
-			_locationsService = locationsService;
-			_itemsService = itemsService;
-			_ordersApi = new OrdersApi( base.ApiConfiguration );
-		}
+        public SquareOrdersService(SquareConfig config, SquareMerchantCredentials credentials,
+            ISquareLocationsService locationsService, ISquareItemsService itemsService) : base(config, credentials)
+        {
+            Condition.Requires(locationsService, "locationsService").IsNotNull();
+            Condition.Requires(itemsService, "itemsService").IsNotNull();
 
-		/// <summary>
-		///	Returns orders created/modified between the start and end date
-		/// </summary>
-		/// <param name="startDateUtc"></param>
-		/// <param name="endDateUtc"></param>
-		/// <param name="token">Cancellation token for cancelling call to endpoint</param>
-		/// <returns></returns>
-		public async Task< IEnumerable< SquareOrder > > GetOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token )
-		{
-			Condition.Requires( startDateUtc ).IsLessThan( endDateUtc );
+            _locationsService = locationsService;
+            _itemsService = itemsService;
+            _ordersApi = new OrdersApi(ApiConfiguration);
+        }
 
-			var mark = Mark.CreateNew();
-			if ( token.IsCancellationRequested )
-			{
-				var exceptionDetails = CreateMethodCallInfo( "", mark, additionalInfo: this.AdditionalLogInfo() );
-				var squareException = new SquareException( string.Format( "{0}. Get orders request was cancelled", exceptionDetails ) );
-				SquareLogger.LogTraceException( squareException );
-				throw squareException;
-			}
+        /// <summary>
+        ///	Returns orders created/modified between the start and end date
+        /// </summary>
+        /// <param name="startDateUtc"></param>
+        /// <param name="endDateUtc"></param>
+        /// <param name="token">Cancellation token for cancelling call to endpoint</param>
+        /// <returns></returns>
+        public async Task<IEnumerable<SquareOrder>> GetOrdersAsync(DateTime startDateUtc, DateTime endDateUtc,
+            CancellationToken token)
+        {
+            Condition.Requires(startDateUtc).IsLessThan(endDateUtc);
 
-			IEnumerable< SquareOrder > response = null;
+            var mark = Mark.CreateNew();
+            if (token.IsCancellationRequested)
+            {
+                var exceptionDetails = CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo());
+                var squareException =
+                    new SquareException(string.Format("{0}. Get orders request was cancelled", exceptionDetails));
+                SquareLogger.LogTraceException(squareException);
+                throw squareException;
+            }
 
-			try
-			{
-				SquareLogger.LogStarted( this.CreateMethodCallInfo( "", mark, additionalInfo: this.AdditionalLogInfo() ) );
+            IEnumerable<SquareOrder> response = null;
 
-				var locations = await _locationsService.GetActiveLocationsAsync( token, mark ).ConfigureAwait( false );
+            try
+            {
+                SquareLogger.LogStarted(CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo()));
 
-				SquareLogger.LogTrace( this.CreateMethodCallInfo( "", mark, payload: locations.ToJson(), additionalInfo: this.AdditionalLogInfo() ) );
+                var locations = await _locationsService.GetActiveLocationsAsync(token, mark).ConfigureAwait(false);
+                if (locations == null || !locations.Any())
+                {
+                    var exceptionDetails = CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo());
+                    var squareException = new SquareException(
+                        $"No active locations. At least one is required to send SearchOrders request. {exceptionDetails}");
+                    SquareLogger.LogTraceException(squareException);
+                    throw squareException;
+                }
 
-				response = await CollectOrdersFromAllPagesAsync( startDateUtc, endDateUtc, locations, 
-					( requestBody ) => GetOrdersWithRelatedDataAsync( requestBody, token, mark ), this.Config.OrdersPageSize ).ConfigureAwait( false );
+                SquareLogger.LogTrace(CreateMethodCallInfo("", mark, payload: locations.ToJson(),
+                    additionalInfo: AdditionalLogInfo()));
 
-				SquareLogger.LogEnd( this.CreateMethodCallInfo( "", mark, additionalInfo: this.AdditionalLogInfo() ) );
-			}
-			catch ( Exception ex )
-			{
-				var squareException = new SquareException( this.CreateMethodCallInfo( "", mark, additionalInfo: this.AdditionalLogInfo() ), ex );
-				SquareLogger.LogTraceException( squareException );
-				throw squareException;
-			}
+                response = await CollectOrdersFromAllPagesAsync(startDateUtc, endDateUtc, locations,
+                        (requestBody) => GetOrdersWithRelatedDataAsync(requestBody, token, mark), Config.OrdersPageSize)
+                    .ConfigureAwait(false);
 
-			return response;
-		}
+                SquareLogger.LogEnd(CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo()));
+            }
+            catch (Exception ex)
+            {
+                var message = $"{ex.Message} {CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo())}";
+                var squareException = new SquareException(message, ex);
+                SquareLogger.LogTraceException(squareException);
+                throw squareException;
+            }
 
-		public static async Task<IEnumerable<SquareOrder>> CollectOrdersFromAllPagesAsync(DateTime startDateUtc,
-			DateTime endDateUtc, IEnumerable<SquareLocation> locations,
-			GetOrdersWithRelatedDataAsyncDelegate getOrdersWithRelatedDataMethod, int ordersPerPage)
-		{
-			var orders = new List<SquareOrder>();
-			// Split locations into batches of 10, as the SearchOrders Square API supports a maximum of 10 location IDs per request. See PBL-9319 for context.
-			var locationBatches = locations.SplitToChunks(MaxLocationBatchSize);
+            return response;
+        }
 
-			foreach (var locationBatch in locationBatches)
-			{
-				var cursor = "";
-				SearchOrdersRequest requestBody;
-				SquareOrdersBatch ordersInPage;
+        public static async Task<IEnumerable<SquareOrder>> CollectOrdersFromAllPagesAsync(DateTime startDateUtc,
+            DateTime endDateUtc, IEnumerable<SquareLocation> locations,
+            GetOrdersWithRelatedDataAsyncDelegate getOrdersWithRelatedDataMethod, int ordersPerPage)
+        {
+            var orders = new List<SquareOrder>();
+            // Split locations into batches of 10, as the SearchOrders Square API supports a maximum of 10 location IDs per request. See PBL-9319 for context.
+            var locationBatches = locations.SplitToChunks(MaxLocationBatchSize);
 
-				do
-				{
-					requestBody =
-						CreateSearchOrdersBody(startDateUtc, endDateUtc, locationBatch, cursor, ordersPerPage);
-					ordersInPage = await getOrdersWithRelatedDataMethod(requestBody).ConfigureAwait(false);
-					if (ordersInPage?.Orders != null)
-					{
-						orders.AddRange(ordersInPage.Orders);
-						cursor = ordersInPage.Cursor;
-					}
-					else
-					{
-						cursor = "";
-					}
-				} while (!string.IsNullOrWhiteSpace(cursor));
-			}
+            foreach (var locationBatch in locationBatches)
+            {
+                var cursor = "";
+                SearchOrdersRequest requestBody;
+                SquareOrdersBatch ordersInPage;
 
-			return orders;
-		}
+                do
+                {
+                    requestBody =
+                        CreateSearchOrdersBody(startDateUtc, endDateUtc, locationBatch, cursor, ordersPerPage);
+                    ordersInPage = await getOrdersWithRelatedDataMethod(requestBody).ConfigureAwait(false);
+                    if (ordersInPage?.Orders != null)
+                    {
+                        orders.AddRange(ordersInPage.Orders);
+                        cursor = ordersInPage.Cursor;
+                    }
+                    else
+                    {
+                        cursor = "";
+                    }
+                } while (!string.IsNullOrWhiteSpace(cursor));
+            }
 
-		private async Task< SquareOrdersBatch > GetOrdersWithRelatedDataAsync( SearchOrdersRequest requestBody, CancellationToken token, Mark mark )
-		{
-			var result = await SearchOrdersAsync( requestBody, token, mark ).ConfigureAwait( false );
+            return orders;
+        }
 
-			if( result != null )
-			{
-				var orders = result.Orders; 
-				var cursor = result.Cursor;
+        private async Task<SquareOrdersBatch> GetOrdersWithRelatedDataAsync(SearchOrdersRequest requestBody,
+            CancellationToken token, Mark mark)
+        {
+            var result = await SearchOrdersAsync(requestBody, token, mark).ConfigureAwait(false);
 
-				var ordersWithRelatedData = new List< SquareOrder >();
+            if (result != null)
+            {
+                var orders = result.Orders;
+                var cursor = result.Cursor;
 
-				if ( orders != null && orders.Any() )
-				{
-					foreach ( var order in orders )
-					{
-						var catalogObjectsIds = ( order.LineItems == null ) ? new List<string>()
-							: order.LineItems.Where( l => l != null && !string.IsNullOrWhiteSpace( l.CatalogObjectId ) ).Select( l => l.CatalogObjectId );
-						var catalogObjects = await _itemsService.GetCatalogObjectsByIdsAsync( catalogObjectsIds, token, mark ).ConfigureAwait( false );
+                var ordersWithRelatedData = new List<SquareOrder>();
 
-						ordersWithRelatedData.Add( order.ToSvOrder( catalogObjects ) );
-					}
+                if (orders != null && orders.Any())
+                {
+                    foreach (var order in orders)
+                    {
+                        var catalogObjectsIds = order.LineItems == null
+                            ? new List<string>()
+                            : order.LineItems.Where(l => l != null && !string.IsNullOrWhiteSpace(l.CatalogObjectId))
+                                .Select(l => l.CatalogObjectId);
+                        var catalogObjects = await _itemsService
+                            .GetCatalogObjectsByIdsAsync(catalogObjectsIds, token, mark).ConfigureAwait(false);
 
-					return new SquareOrdersBatch
-					{
-						Orders = ordersWithRelatedData,
-						Cursor = cursor
-					};
-				}
-			}
+                        ordersWithRelatedData.Add(order.ToSvOrder(catalogObjects));
+                    }
 
-			return new SquareOrdersBatch
-			{
-				Orders = new List< SquareOrder >(),
-				Cursor = null
-			};
-		}
+                    return new SquareOrdersBatch
+                    {
+                        Orders = ordersWithRelatedData,
+                        Cursor = cursor
+                    };
+                }
+            }
 
-		private async Task< SearchOrdersResponse > SearchOrdersAsync( SearchOrdersRequest requestBody, CancellationToken token, Mark mark )
-		{
-			if ( token.IsCancellationRequested )
-			{
-				var exceptionDetails = CreateMethodCallInfo( SquareEndPoint.OrdersSearchUrl, mark, additionalInfo: this.AdditionalLogInfo() );
-				var squareException = new SquareException( string.Format( "{0}. Search orders request was cancelled", exceptionDetails ) );
-				SquareLogger.LogTraceException( squareException );
-				throw squareException;
-			}
+            return new SquareOrdersBatch
+            {
+                Orders = new List<SquareOrder>(),
+                Cursor = null
+            };
+        }
 
-			var response = await base.ThrottleRequest( SquareEndPoint.SearchCatalogUrl, requestBody.ToJson(), mark, ( _ ) =>
-			{
-				return  _ordersApi.SearchOrdersAsync( requestBody );
-			}, token ).ConfigureAwait( false );
+        private async Task<SearchOrdersResponse> SearchOrdersAsync(SearchOrdersRequest requestBody,
+            CancellationToken token, Mark mark)
+        {
+            if (token.IsCancellationRequested)
+            {
+                var exceptionDetails = CreateMethodCallInfo(SquareEndPoint.OrdersSearchUrl, mark,
+                    additionalInfo: AdditionalLogInfo());
+                var squareException =
+                    new SquareException(string.Format("{0}. Search orders request was cancelled", exceptionDetails));
+                SquareLogger.LogTraceException(squareException);
+                throw squareException;
+            }
 
-			var errors = response.Errors;
-			if ( errors != null && errors.Any() )
-			{
-				var methodCallInfo = CreateMethodCallInfo( SquareEndPoint.OrdersSearchUrl, mark, additionalInfo: this.AdditionalLogInfo(), errors: errors.ToJson(), payload: requestBody.ToJson() );
-				var squareException = new SquareException( string.Format( "{0}. Search orders returned errors", methodCallInfo ) );
-				SquareLogger.LogTraceException( squareException );
-				throw squareException;
-			}
+            var response = await ThrottleRequest(SquareEndPoint.SearchCatalogUrl, requestBody.ToJson(), mark,
+                (_) => { return _ordersApi.SearchOrdersAsync(requestBody); }, token).ConfigureAwait(false);
 
-			return response;
-		}
+            var errors = response.Errors;
+            if (errors != null && errors.Any())
+            {
+                var methodCallInfo = CreateMethodCallInfo(SquareEndPoint.OrdersSearchUrl, mark,
+                    additionalInfo: AdditionalLogInfo(), errors: errors.ToJson(), payload: requestBody.ToJson());
+                var squareException =
+                    new SquareException(string.Format("{0}. Search orders returned errors", methodCallInfo));
+                SquareLogger.LogTraceException(squareException);
+                throw squareException;
+            }
 
-		public static SearchOrdersRequest CreateSearchOrdersBody( DateTime startDateUtc, DateTime endDateUtc, IEnumerable< SquareLocation > locations, string cursor, int ordersPerPage )
-		{
-			var updatedAtStart = startDateUtc.FromUtcToRFC3339();
-			var updatedAtEnd = endDateUtc.FromUtcToRFC3339();
+            return response;
+        }
 
-			var body = new SearchOrdersRequest
-			{
-				ReturnEntries = false,
-				Limit = ordersPerPage,
-				LocationIds = locations.Select( l => l.Id ).ToList(),
-				Query = new SearchOrdersQuery
-				{
-					Filter = new SearchOrdersFilter
-					{
-						DateTimeFilter = new SearchOrdersDateTimeFilter
-						{
-							UpdatedAt = new TimeRange
-							{
-								StartAt = updatedAtStart,
-								EndAt = updatedAtEnd
-							}
-						},
-						StateFilter = new SearchOrdersStateFilter( 
-							new List< string >
-							{
-								SquareOrderState.Completed,
-								SquareOrderState.Open,
-								SquareOrderState.Cancelled
-							}
-						)
-					},
-					Sort = new SearchOrdersSort("UPDATED_AT", "DESC")
-				}
-			};
+        public static SearchOrdersRequest CreateSearchOrdersBody(DateTime startDateUtc, DateTime endDateUtc,
+            IEnumerable<SquareLocation> locations, string cursor, int ordersPerPage)
+        {
+            var updatedAtStart = startDateUtc.FromUtcToRFC3339();
+            var updatedAtEnd = endDateUtc.FromUtcToRFC3339();
 
-			if( !string.IsNullOrWhiteSpace( cursor ))
-			{
-				body.Cursor = cursor;
-			}
+            var body = new SearchOrdersRequest
+            {
+                ReturnEntries = false,
+                Limit = ordersPerPage,
+                LocationIds = locations.Select(l => l.Id).ToList(),
+                Query = new SearchOrdersQuery
+                {
+                    Filter = new SearchOrdersFilter
+                    {
+                        DateTimeFilter = new SearchOrdersDateTimeFilter
+                        {
+                            UpdatedAt = new TimeRange
+                            {
+                                StartAt = updatedAtStart,
+                                EndAt = updatedAtEnd
+                            }
+                        },
+                        StateFilter = new SearchOrdersStateFilter(
+                            new List<string>
+                            {
+                                SquareOrderState.Completed,
+                                SquareOrderState.Open,
+                                SquareOrderState.Cancelled
+                            }
+                        )
+                    },
+                    Sort = new SearchOrdersSort("UPDATED_AT", "DESC")
+                }
+            };
 
-			return body;
-		}
-	}
+            if (!string.IsNullOrWhiteSpace(cursor)) body.Cursor = cursor;
+
+            return body;
+        }
+    }
 }

--- a/src/SquareAccess/Services/Orders/SquareOrdersService.cs
+++ b/src/SquareAccess/Services/Orders/SquareOrdersService.cs
@@ -15,228 +15,217 @@ using SquareAccess.Shared;
 
 namespace SquareAccess.Services.Orders
 {
-    public sealed class SquareOrdersService : AuthorizedBaseService, ISquareOrdersService
-    {
-        private readonly ISquareLocationsService _locationsService;
-        private readonly ISquareItemsService _itemsService;
-        private readonly OrdersApi _ordersApi;
-        private const int MaxLocationBatchSize = 10;
+	public sealed class SquareOrdersService : AuthorizedBaseService, ISquareOrdersService
+	{
+		private readonly ISquareLocationsService _locationsService;
+		private readonly ISquareItemsService _itemsService;
+		private readonly OrdersApi _ordersApi;
+		private const int MaxLocationBatchSize = 10;
+		public delegate Task< SquareOrdersBatch > GetOrdersWithRelatedDataAsyncDelegate( SearchOrdersRequest requestBody );
 
-        public delegate Task<SquareOrdersBatch> GetOrdersWithRelatedDataAsyncDelegate(SearchOrdersRequest requestBody);
+		public SquareOrdersService( SquareConfig config, SquareMerchantCredentials credentials, ISquareLocationsService locationsService, ISquareItemsService itemsService ) : base( config, credentials )
+		{
+			Condition.Requires( locationsService, "locationsService" ).IsNotNull();
+			Condition.Requires( itemsService, "itemsService" ).IsNotNull();
 
-        public SquareOrdersService(SquareConfig config, SquareMerchantCredentials credentials,
-            ISquareLocationsService locationsService, ISquareItemsService itemsService) : base(config, credentials)
-        {
-            Condition.Requires(locationsService, "locationsService").IsNotNull();
-            Condition.Requires(itemsService, "itemsService").IsNotNull();
+			_locationsService = locationsService;
+			_itemsService = itemsService;
+			_ordersApi = new OrdersApi( base.ApiConfiguration );
+		}
 
-            _locationsService = locationsService;
-            _itemsService = itemsService;
-            _ordersApi = new OrdersApi(ApiConfiguration);
-        }
+		/// <summary>
+		///	Returns orders created/modified between the start and end date
+		/// </summary>
+		/// <param name="startDateUtc"></param>
+		/// <param name="endDateUtc"></param>
+		/// <param name="token">Cancellation token for cancelling call to endpoint</param>
+		/// <returns></returns>
+		public async Task< IEnumerable< SquareOrder > > GetOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token )
+		{
+			Condition.Requires( startDateUtc ).IsLessThan( endDateUtc );
 
-        /// <summary>
-        ///	Returns orders created/modified between the start and end date
-        /// </summary>
-        /// <param name="startDateUtc"></param>
-        /// <param name="endDateUtc"></param>
-        /// <param name="token">Cancellation token for cancelling call to endpoint</param>
-        /// <returns></returns>
-        public async Task<IEnumerable<SquareOrder>> GetOrdersAsync(DateTime startDateUtc, DateTime endDateUtc,
-            CancellationToken token)
-        {
-            Condition.Requires(startDateUtc).IsLessThan(endDateUtc);
+			var mark = Mark.CreateNew();
+			if ( token.IsCancellationRequested )
+			{
+				var exceptionDetails = CreateMethodCallInfo( "", mark, additionalInfo: this.AdditionalLogInfo() );
+				var squareException = new SquareException( string.Format( "{0}. Get orders request was cancelled", exceptionDetails ) );
+				SquareLogger.LogTraceException( squareException );
+				throw squareException;
+			}
 
-            var mark = Mark.CreateNew();
-            if (token.IsCancellationRequested)
-            {
-                var exceptionDetails = CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo());
-                var squareException =
-                    new SquareException(string.Format("{0}. Get orders request was cancelled", exceptionDetails));
-                SquareLogger.LogTraceException(squareException);
-                throw squareException;
-            }
+			IEnumerable< SquareOrder > response = null;
 
-            IEnumerable<SquareOrder> response = null;
+			try
+			{
+				SquareLogger.LogStarted(CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo()));
 
-            try
-            {
-                SquareLogger.LogStarted(CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo()));
+				var locations = await _locationsService.GetActiveLocationsAsync(token, mark).ConfigureAwait(false);
+				if (locations == null || !locations.Any())
+				{
+					var exceptionDetails = CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo());
+					var squareException = new SquareException(
+						$"No active locations. At least one is required to send SearchOrders request. {exceptionDetails}");
+					SquareLogger.LogTraceException(squareException);
+					throw squareException;
+				}
 
-                var locations = await _locationsService.GetActiveLocationsAsync(token, mark).ConfigureAwait(false);
-                if (locations == null || !locations.Any())
-                {
-                    var exceptionDetails = CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo());
-                    var squareException = new SquareException(
-                        $"No active locations. At least one is required to send SearchOrders request. {exceptionDetails}");
-                    SquareLogger.LogTraceException(squareException);
-                    throw squareException;
-                }
+				SquareLogger.LogTrace( this.CreateMethodCallInfo( "", mark, payload: locations.ToJson(), additionalInfo: this.AdditionalLogInfo() ) );
 
-                SquareLogger.LogTrace(CreateMethodCallInfo("", mark, payload: locations.ToJson(),
-                    additionalInfo: AdditionalLogInfo()));
+				response = await CollectOrdersFromAllPagesAsync( startDateUtc, endDateUtc, locations, 
+					( requestBody ) => GetOrdersWithRelatedDataAsync( requestBody, token, mark ), this.Config.OrdersPageSize ).ConfigureAwait( false );
 
-                response = await CollectOrdersFromAllPagesAsync(startDateUtc, endDateUtc, locations,
-                        (requestBody) => GetOrdersWithRelatedDataAsync(requestBody, token, mark), Config.OrdersPageSize)
-                    .ConfigureAwait(false);
+				SquareLogger.LogEnd(CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo()));
+			}
+			catch (Exception ex)
+			{
+				var message = $"{ex.Message} {CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo())}";
+				var squareException = new SquareException(message, ex);
+				SquareLogger.LogTraceException(squareException);
+				throw squareException;
+			}
 
-                SquareLogger.LogEnd(CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo()));
-            }
-            catch (Exception ex)
-            {
-                var message = $"{ex.Message} {CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo())}";
-                var squareException = new SquareException(message, ex);
-                SquareLogger.LogTraceException(squareException);
-                throw squareException;
-            }
+			return response;
+		}
 
-            return response;
-        }
+		public static async Task<IEnumerable<SquareOrder>> CollectOrdersFromAllPagesAsync(DateTime startDateUtc,
+			DateTime endDateUtc, IEnumerable<SquareLocation> locations,
+			GetOrdersWithRelatedDataAsyncDelegate getOrdersWithRelatedDataMethod, int ordersPerPage)
+		{
+			var orders = new List<SquareOrder>();
+			// Split locations into batches of 10, as the SearchOrders Square API supports a maximum of 10 location IDs per request. See PBL-9319 for context.
+			var locationBatches = locations.SplitToChunks(MaxLocationBatchSize);
 
-        public static async Task<IEnumerable<SquareOrder>> CollectOrdersFromAllPagesAsync(DateTime startDateUtc,
-            DateTime endDateUtc, IEnumerable<SquareLocation> locations,
-            GetOrdersWithRelatedDataAsyncDelegate getOrdersWithRelatedDataMethod, int ordersPerPage)
-        {
-            var orders = new List<SquareOrder>();
-            // Split locations into batches of 10, as the SearchOrders Square API supports a maximum of 10 location IDs per request. See PBL-9319 for context.
-            var locationBatches = locations.SplitToChunks(MaxLocationBatchSize);
+			foreach (var locationBatch in locationBatches)
+			{
+				var cursor = "";
+				SearchOrdersRequest requestBody;
+				SquareOrdersBatch ordersInPage;
 
-            foreach (var locationBatch in locationBatches)
-            {
-                var cursor = "";
-                SearchOrdersRequest requestBody;
-                SquareOrdersBatch ordersInPage;
+				do
+				{
+					requestBody =
+						CreateSearchOrdersBody(startDateUtc, endDateUtc, locationBatch, cursor, ordersPerPage);
+					ordersInPage = await getOrdersWithRelatedDataMethod(requestBody).ConfigureAwait(false);
+					if (ordersInPage?.Orders != null)
+					{
+						orders.AddRange(ordersInPage.Orders);
+						cursor = ordersInPage.Cursor;
+					}
+					else
+					{
+						cursor = "";
+					}
+				} while (!string.IsNullOrWhiteSpace(cursor));
+			}
 
-                do
-                {
-                    requestBody =
-                        CreateSearchOrdersBody(startDateUtc, endDateUtc, locationBatch, cursor, ordersPerPage);
-                    ordersInPage = await getOrdersWithRelatedDataMethod(requestBody).ConfigureAwait(false);
-                    if (ordersInPage?.Orders != null)
-                    {
-                        orders.AddRange(ordersInPage.Orders);
-                        cursor = ordersInPage.Cursor;
-                    }
-                    else
-                    {
-                        cursor = "";
-                    }
-                } while (!string.IsNullOrWhiteSpace(cursor));
-            }
+			return orders;
+		}
 
-            return orders;
-        }
+		private async Task< SquareOrdersBatch > GetOrdersWithRelatedDataAsync( SearchOrdersRequest requestBody, CancellationToken token, Mark mark )
+		{
+			var result = await SearchOrdersAsync( requestBody, token, mark ).ConfigureAwait( false );
 
-        private async Task<SquareOrdersBatch> GetOrdersWithRelatedDataAsync(SearchOrdersRequest requestBody,
-            CancellationToken token, Mark mark)
-        {
-            var result = await SearchOrdersAsync(requestBody, token, mark).ConfigureAwait(false);
+			if( result != null )
+			{
+				var orders = result.Orders; 
+				var cursor = result.Cursor;
 
-            if (result != null)
-            {
-                var orders = result.Orders;
-                var cursor = result.Cursor;
+				var ordersWithRelatedData = new List< SquareOrder >();
 
-                var ordersWithRelatedData = new List<SquareOrder>();
+				if ( orders != null && orders.Any() )
+				{
+					foreach ( var order in orders )
+					{
+						var catalogObjectsIds = ( order.LineItems == null ) ? new List<string>()
+							: order.LineItems.Where( l => l != null && !string.IsNullOrWhiteSpace( l.CatalogObjectId ) ).Select( l => l.CatalogObjectId );
+						var catalogObjects = await _itemsService.GetCatalogObjectsByIdsAsync( catalogObjectsIds, token, mark ).ConfigureAwait( false );
 
-                if (orders != null && orders.Any())
-                {
-                    foreach (var order in orders)
-                    {
-                        var catalogObjectsIds = order.LineItems == null
-                            ? new List<string>()
-                            : order.LineItems.Where(l => l != null && !string.IsNullOrWhiteSpace(l.CatalogObjectId))
-                                .Select(l => l.CatalogObjectId);
-                        var catalogObjects = await _itemsService
-                            .GetCatalogObjectsByIdsAsync(catalogObjectsIds, token, mark).ConfigureAwait(false);
+						ordersWithRelatedData.Add( order.ToSvOrder( catalogObjects ) );
+					}
 
-                        ordersWithRelatedData.Add(order.ToSvOrder(catalogObjects));
-                    }
+					return new SquareOrdersBatch
+					{
+						Orders = ordersWithRelatedData,
+						Cursor = cursor
+					};
+				}
+			}
 
-                    return new SquareOrdersBatch
-                    {
-                        Orders = ordersWithRelatedData,
-                        Cursor = cursor
-                    };
-                }
-            }
+			return new SquareOrdersBatch
+			{
+				Orders = new List< SquareOrder >(),
+				Cursor = null
+			};
+		}
 
-            return new SquareOrdersBatch
-            {
-                Orders = new List<SquareOrder>(),
-                Cursor = null
-            };
-        }
+		private async Task< SearchOrdersResponse > SearchOrdersAsync( SearchOrdersRequest requestBody, CancellationToken token, Mark mark )
+		{
+			if ( token.IsCancellationRequested )
+			{
+				var exceptionDetails = CreateMethodCallInfo( SquareEndPoint.OrdersSearchUrl, mark, additionalInfo: this.AdditionalLogInfo() );
+				var squareException = new SquareException( string.Format( "{0}. Search orders request was cancelled", exceptionDetails ) );
+				SquareLogger.LogTraceException( squareException );
+				throw squareException;
+			}
 
-        private async Task<SearchOrdersResponse> SearchOrdersAsync(SearchOrdersRequest requestBody,
-            CancellationToken token, Mark mark)
-        {
-            if (token.IsCancellationRequested)
-            {
-                var exceptionDetails = CreateMethodCallInfo(SquareEndPoint.OrdersSearchUrl, mark,
-                    additionalInfo: AdditionalLogInfo());
-                var squareException =
-                    new SquareException(string.Format("{0}. Search orders request was cancelled", exceptionDetails));
-                SquareLogger.LogTraceException(squareException);
-                throw squareException;
-            }
+			var response = await base.ThrottleRequest( SquareEndPoint.SearchCatalogUrl, requestBody.ToJson(), mark, ( _ ) =>
+			{
+				return  _ordersApi.SearchOrdersAsync( requestBody );
+			}, token ).ConfigureAwait( false );
 
-            var response = await ThrottleRequest(SquareEndPoint.SearchCatalogUrl, requestBody.ToJson(), mark,
-                (_) => { return _ordersApi.SearchOrdersAsync(requestBody); }, token).ConfigureAwait(false);
+			var errors = response.Errors;
+			if ( errors != null && errors.Any() )
+			{
+				var methodCallInfo = CreateMethodCallInfo( SquareEndPoint.OrdersSearchUrl, mark, additionalInfo: this.AdditionalLogInfo(), errors: errors.ToJson(), payload: requestBody.ToJson() );
+				var squareException = new SquareException( string.Format( "{0}. Search orders returned errors", methodCallInfo ) );
+				SquareLogger.LogTraceException( squareException );
+				throw squareException;
+			}
 
-            var errors = response.Errors;
-            if (errors != null && errors.Any())
-            {
-                var methodCallInfo = CreateMethodCallInfo(SquareEndPoint.OrdersSearchUrl, mark,
-                    additionalInfo: AdditionalLogInfo(), errors: errors.ToJson(), payload: requestBody.ToJson());
-                var squareException =
-                    new SquareException(string.Format("{0}. Search orders returned errors", methodCallInfo));
-                SquareLogger.LogTraceException(squareException);
-                throw squareException;
-            }
+			return response;
+		}
 
-            return response;
-        }
+		public static SearchOrdersRequest CreateSearchOrdersBody( DateTime startDateUtc, DateTime endDateUtc, IEnumerable< SquareLocation > locations, string cursor, int ordersPerPage )
+		{
+			var updatedAtStart = startDateUtc.FromUtcToRFC3339();
+			var updatedAtEnd = endDateUtc.FromUtcToRFC3339();
 
-        public static SearchOrdersRequest CreateSearchOrdersBody(DateTime startDateUtc, DateTime endDateUtc,
-            IEnumerable<SquareLocation> locations, string cursor, int ordersPerPage)
-        {
-            var updatedAtStart = startDateUtc.FromUtcToRFC3339();
-            var updatedAtEnd = endDateUtc.FromUtcToRFC3339();
+			var body = new SearchOrdersRequest
+			{
+				ReturnEntries = false,
+				Limit = ordersPerPage,
+				LocationIds = locations.Select( l => l.Id ).ToList(),
+				Query = new SearchOrdersQuery
+				{
+					Filter = new SearchOrdersFilter
+					{
+						DateTimeFilter = new SearchOrdersDateTimeFilter
+						{
+							UpdatedAt = new TimeRange
+							{
+								StartAt = updatedAtStart,
+								EndAt = updatedAtEnd
+							}
+						},
+						StateFilter = new SearchOrdersStateFilter( 
+							new List< string >
+							{
+								SquareOrderState.Completed,
+								SquareOrderState.Open,
+								SquareOrderState.Cancelled
+							}
+						)
+					},
+					Sort = new SearchOrdersSort("UPDATED_AT", "DESC")
+				}
+			};
 
-            var body = new SearchOrdersRequest
-            {
-                ReturnEntries = false,
-                Limit = ordersPerPage,
-                LocationIds = locations.Select(l => l.Id).ToList(),
-                Query = new SearchOrdersQuery
-                {
-                    Filter = new SearchOrdersFilter
-                    {
-                        DateTimeFilter = new SearchOrdersDateTimeFilter
-                        {
-                            UpdatedAt = new TimeRange
-                            {
-                                StartAt = updatedAtStart,
-                                EndAt = updatedAtEnd
-                            }
-                        },
-                        StateFilter = new SearchOrdersStateFilter(
-                            new List<string>
-                            {
-                                SquareOrderState.Completed,
-                                SquareOrderState.Open,
-                                SquareOrderState.Cancelled
-                            }
-                        )
-                    },
-                    Sort = new SearchOrdersSort("UPDATED_AT", "DESC")
-                }
-            };
+			if( !string.IsNullOrWhiteSpace( cursor ))
+			{
+				body.Cursor = cursor;
+			}
 
-            if (!string.IsNullOrWhiteSpace(cursor)) body.Cursor = cursor;
-
-            return body;
-        }
-    }
+			return body;
+		}
+	}
 }

--- a/src/SquareAccess/Services/Orders/SquareOrdersService.cs
+++ b/src/SquareAccess/Services/Orders/SquareOrdersService.cs
@@ -40,20 +40,22 @@ namespace SquareAccess.Services.Orders
 		/// <param name="endDateUtc"></param>
 		/// <param name="token">Cancellation token for cancelling call to endpoint</param>
 		/// <returns></returns>
-		public async Task< IEnumerable< SquareOrder > > GetOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, CancellationToken token )
+		public async Task<IEnumerable<SquareOrder>> GetOrdersAsync(DateTime startDateUtc, DateTime endDateUtc,
+			CancellationToken token)
 		{
-			Condition.Requires( startDateUtc ).IsLessThan( endDateUtc );
+			Condition.Requires(startDateUtc).IsLessThan(endDateUtc);
 
 			var mark = Mark.CreateNew();
-			if ( token.IsCancellationRequested )
+			if (token.IsCancellationRequested)
 			{
-				var exceptionDetails = CreateMethodCallInfo( "", mark, additionalInfo: this.AdditionalLogInfo() );
-				var squareException = new SquareException( string.Format( "{0}. Get orders request was cancelled", exceptionDetails ) );
-				SquareLogger.LogTraceException( squareException );
+				var exceptionDetails = CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo());
+				var squareException =
+					new SquareException(string.Format("{0}. Get orders request was cancelled", exceptionDetails));
+				SquareLogger.LogTraceException(squareException);
 				throw squareException;
 			}
 
-			IEnumerable< SquareOrder > response = null;
+			IEnumerable<SquareOrder> response = null;
 
 			try
 			{
@@ -69,10 +71,12 @@ namespace SquareAccess.Services.Orders
 					throw squareException;
 				}
 
-				SquareLogger.LogTrace( this.CreateMethodCallInfo( "", mark, payload: locations.ToJson(), additionalInfo: this.AdditionalLogInfo() ) );
+				SquareLogger.LogTrace(CreateMethodCallInfo("", mark, payload: locations.ToJson(),
+					additionalInfo: AdditionalLogInfo()));
 
-				response = await CollectOrdersFromAllPagesAsync( startDateUtc, endDateUtc, locations, 
-					( requestBody ) => GetOrdersWithRelatedDataAsync( requestBody, token, mark ), this.Config.OrdersPageSize ).ConfigureAwait( false );
+				response = await CollectOrdersFromAllPagesAsync(startDateUtc, endDateUtc, locations,
+						(requestBody) => GetOrdersWithRelatedDataAsync(requestBody, token, mark), Config.OrdersPageSize)
+					.ConfigureAwait(false);
 
 				SquareLogger.LogEnd(CreateMethodCallInfo("", mark, additionalInfo: AdditionalLogInfo()));
 			}

--- a/src/SquareAccess/SquareAccess.csproj
+++ b/src/SquareAccess/SquareAccess.csproj
@@ -4,15 +4,15 @@
     <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
     <Authors>SkuVault</Authors>
     <Company>SkuVault</Company>
-    <Version>1.1.12.0</Version>
+    <Version>1.1.13.0-alpha.1</Version>
     <Description>SquareAccess webservices API wrapper</Description>
     <Copyright>SkuVault © 2019-2021</Copyright>
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/squareAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/squareAccess</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.1.12.0</AssemblyVersion>
-    <FileVersion>1.1.12.0</FileVersion>
+    <AssemblyVersion>1.1.13.0</AssemblyVersion>
+    <FileVersion>1.1.13.0</FileVersion>
     <PackageId>SquareAccess</PackageId>
     <Product>SquareAccess</Product>
   </PropertyGroup>

--- a/src/SquareAccessTests/Mocks/FakeLocationsService.cs
+++ b/src/SquareAccessTests/Mocks/FakeLocationsService.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Square.Connect.Model;
 using SquareAccess.Models;
 using SquareAccess.Services.Locations;
 using SquareAccess.Shared;
@@ -12,26 +12,31 @@ namespace SquareAccessTests.Mocks
 	public class FakeLocationsService : ISquareLocationsService
 	{
 		private readonly string _locationId;
-		
-		public FakeLocationsService( string locationId )
+		private readonly Func<IEnumerable<SquareLocation>> _getLocations;
+
+		public FakeLocationsService(string locationId)
 		{
 			_locationId = locationId;
+			_getLocations = () => new[] { new SquareLocation { Id = _locationId, Active = true } };
+		}
+
+		public FakeLocationsService(Func<IEnumerable<SquareLocation>> getLocations)
+		{
+			_getLocations = getLocations;
 		}
 
 		public void Dispose()
 		{
 		}
 
-		public Task< IEnumerable< SquareLocation > > GetActiveLocationsAsync(CancellationToken token, Mark mark)
+		public Task<IEnumerable<SquareLocation>> GetActiveLocationsAsync(CancellationToken token, Mark mark)
 		{
-			return GetLocationsAsync( token, mark );
+			return Task.FromResult(_getLocations().Where(l => l.Active));
 		}
 
-		public Task< IEnumerable< SquareLocation > > GetLocationsAsync( CancellationToken token, Mark mark )
+		public Task<IEnumerable<SquareLocation>> GetLocationsAsync(CancellationToken token, Mark mark)
 		{
-			var locations = new SquareLocation[] { new SquareLocation() { Id = _locationId, Active = true } }.ToList();
-
-			return Task.FromResult( locations.AsEnumerable() );
+			return Task.FromResult(_getLocations());
 		}
 	}
 }

--- a/src/SquareAccessTests/Mocks/FakeOrdersService.cs
+++ b/src/SquareAccessTests/Mocks/FakeOrdersService.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Square.Connect.Model;
+using SquareAccess.Models;
+
+namespace SquareAccessTests.Mocks
+{
+    public class FakeOrdersService
+    {
+        public List<int> CallCounts { get; } = new List<int>();
+
+        public async Task<SquareOrdersBatch> MockGetOrdersWithRelatedDataMethod(SearchOrdersRequest request)
+        {
+            CallCounts.Add(request.LocationIds.Count());
+            return await Task.FromResult(new SquareOrdersBatch
+            {
+                Orders = new List<SquareOrder> { new SquareOrder() },
+                Cursor = null
+            });
+        }
+    }
+}

--- a/src/SquareAccessTests/OrdersServiceTests.cs
+++ b/src/SquareAccessTests/OrdersServiceTests.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
 using NUnit.Framework;
 using Square.Connect.Model;
+using SquareAccess.Exceptions;
 using SquareAccess.Models;
 using SquareAccess.Models.Items;
 using SquareAccess.Services.Orders;
@@ -14,184 +14,214 @@ using SquareAccessTests.Mocks;
 
 namespace SquareAccessTests
 {
-	public class OrdersServiceTests : BaseTest
-	{
-		private ISquareOrdersService _ordersService;
-		private bool _firstPage;
-		private const string TestLocationId = "1GZS83Z3FC3Y3";
-		private readonly DateTime startDateUtc = DateTime.UtcNow.AddDays(-20);
-		private readonly DateTime endDateUtc = DateTime.UtcNow;		
+    public class OrdersServiceTests : BaseTest
+    {
+        private ISquareOrdersService _ordersService;
+        private bool _firstPage;
+        private const string TestLocationId = "1GZS83Z3FC3Y3";
+        private readonly DateTime startDateUtc = DateTime.UtcNow.AddDays(-700);
+        private readonly DateTime endDateUtc = DateTime.UtcNow;
 
-		[ SetUp ]
-		public void Init()
-		{
-			this._ordersService = new SquareOrdersService( this.Config, this.Credentials, new FakeLocationsService( TestLocationId ), new FakeSquareItemsService() );
-		}
+        [SetUp]
+        public void Init()
+        {
+            _ordersService = new SquareOrdersService(Config, Credentials, new FakeLocationsService(TestLocationId),
+                new FakeSquareItemsService());
+        }
 
-		[ Test ]
-		public void GetOrdersAsync()
-		{						
-			var result = _ordersService.GetOrdersAsync( startDateUtc, endDateUtc, CancellationToken.None ).Result;
+        [Test]
+        public void GetOrdersAsync()
+        {
+            var result = _ordersService.GetOrdersAsync(startDateUtc, endDateUtc, CancellationToken.None).Result;
 
-			result.Should().NotBeEmpty();
-		}
+            Assert.That(result, Is.Not.Empty);
+        }
 
-		[ Test ]
-		public void GetOrdersAsync_ByPage()
-		{			
-			this.Config.OrdersPageSize = 2;
+        [Test]
+        public void GetOrdersAsync_ByPage()
+        {
+            Config.OrdersPageSize = 2;
 
-			var result = _ordersService.GetOrdersAsync( startDateUtc, endDateUtc, CancellationToken.None ).Result;
+            var result = _ordersService.GetOrdersAsync(startDateUtc, endDateUtc, CancellationToken.None).Result;
 
-			result.Count().Should().BeGreaterOrEqualTo( 2 );
-		}
+            Assert.That(result.Count(), Is.GreaterThanOrEqualTo(2));
+        }
 
-		[ Test ]
-		public void CreateSearchOrdersBody()
-		{						
-			var locations = new List< SquareLocation >
-			{
-				new SquareLocation
-				{
-					Id = "i2o3jeo"
-				},
-				new SquareLocation
-				{
-					Id = "aidfj23i"
-				}
-			};
-			const string cursor = "23984ej2";
-			const int ordersPerPage = 10;
+        [Test]
+        public async Task GetOrdersAsync_ShouldThrowException_WhenNoLocations()
+        {
+            // Arrange
+            var service = new SquareOrdersService(
+                Config,
+                Credentials,
+                new FakeLocationsService(() => Enumerable.Empty<SquareLocation>()),
+                new FakeSquareItemsService()
+            );
 
-			var result = SquareOrdersService.CreateSearchOrdersBody( startDateUtc, endDateUtc, locations.AsEnumerable(), cursor, ordersPerPage );
+            // Act & Assert
+            var exception = Assert.ThrowsAsync<SquareException>(async () =>
+            {
+                await service.GetOrdersAsync(startDateUtc, endDateUtc, CancellationToken.None);
+            });
 
-			result.LocationIds.Should().BeEquivalentTo( locations.Select( l => l.Id ) );
-			result.Cursor.Should().Be( cursor );
-			result.Limit.Should().Be( ordersPerPage );
-			result.Query.Filter.DateTimeFilter.UpdatedAt.StartAt.Should().Be( startDateUtc.FromUtcToRFC3339() );
-			result.Query.Filter.DateTimeFilter.UpdatedAt.EndAt.Should().Be( endDateUtc.FromUtcToRFC3339() );
-		}
+            Assert.That(
+                exception?.Message,
+                Does.Contain("No active locations. At least one is required to send SearchOrders request.")
+            );
+        }
 
-		[ Test ]
-		public void CollectOrdersFromAllPagesAsync()
-		{			
-			const int ordersPerPage = 2;
-			_firstPage = true;
-			const string catalogObjectId = "asldfjlkj";
-			const string quantity = "13";
-			var recipient = new OrderFulfillmentRecipient
-			{
-				DisplayName = "Bubba"
-			};
-			var orders = new List< Order >
-			{
-				new Order( "alkdsf23", "i2o3jeo" )
-				{
-					CreatedAt = "2019-01-03T05:07:51Z",
-					UpdatedAt = "2019-02-03T05:07:51Z",
-					LineItems = new List< OrderLineItem >
-					{
-						new OrderLineItem( null, null, Quantity: quantity )
-						{
-							CatalogObjectId = catalogObjectId,
-						}
-					},
-					Fulfillments = new List< OrderFulfillment >
-					{
-						new OrderFulfillment
-						{
-							ShipmentDetails = new OrderFulfillmentShipmentDetails
-							{
-								Recipient = recipient
-							}
-						}
-					}
-				},
-				new Order( "23ik4lkj", "aidfj23i" )
-				{
-					CreatedAt = "2019-01-03T05:07:51Z",
-					UpdatedAt = "2019-02-03T05:07:51Z"
-				}
-			};
-			const string sku = "testSku1";
-			
-			var items = new List< SquareItem >
-			{
-				new SquareItem
-				{
-					VariationId = catalogObjectId,
-					Sku = sku
-				}
-			};
+        [Test]
+        public void CreateSearchOrdersBody()
+        {
+            // Arrange
+            var locations = new List<SquareLocation>
+            {
+                new SquareLocation
+                {
+                    Id = "i2o3jeo"
+                },
+                new SquareLocation
+                {
+                    Id = "aidfj23i"
+                }
+            };
+            const string cursor = "23984ej2";
+            const int ordersPerPage = 10;
 
-			var result = SquareOrdersService.CollectOrdersFromAllPagesAsync( startDateUtc, endDateUtc, new List< SquareLocation >(), 
-				( requestBody ) => GetOrdersWithRelatedData( orders, items ), ordersPerPage ).Result.ToList();
+            // Act
+            var result = SquareOrdersService.CreateSearchOrdersBody(startDateUtc, endDateUtc, locations.AsEnumerable(),
+                cursor, ordersPerPage);
 
-			result.Count.Should().Be( 2 );
-			var firstOrder = result.First();
-			firstOrder.OrderId.Should().BeEquivalentTo( orders.First().Id );
-			firstOrder.Recipient.Name.Should().BeEquivalentTo( recipient.DisplayName );
-			var firstLineItem = firstOrder.LineItems.First();
-			firstLineItem.Sku.Should().Be( sku );
-			firstLineItem.Quantity.Should().Be( quantity );
-			result.Skip( 1 ).First().OrderId.Should().BeEquivalentTo( orders.Skip( 1 ).First().Id );
-		}
-		
-		[Test]
-		public async Task CollectOrdersFromAllPagesAsync_ShouldBatchLocationsCorrectly()
-		{
-			// Arrange
-			var locations = Enumerable.Range(1, 25).Select(i => new SquareLocation { Id = i.ToString() }).ToList();
-			const int ordersPerPage = 5;
+            // Assert
+            Assert.That(result.LocationIds, Is.EquivalentTo(locations.Select(l => l.Id)));
+            Assert.That(result.Cursor, Is.EqualTo(cursor));
+            Assert.That(result.Limit, Is.EqualTo(ordersPerPage));
+            Assert.That(result.Query.Filter.DateTimeFilter.UpdatedAt.StartAt,
+                Is.EqualTo(startDateUtc.FromUtcToRFC3339()));
+            Assert.That(result.Query.Filter.DateTimeFilter.UpdatedAt.EndAt, Is.EqualTo(endDateUtc.FromUtcToRFC3339()));
+        }
 
-			var fakeOrdersService = new FakeOrdersService();
+        [Test]
+        public void CollectOrdersFromAllPagesAsync()
+        {
+            // Act
+            const int ordersPerPage = 2;
+            _firstPage = true;
+            const string catalogObjectId = "asldfjlkj";
+            const string quantity = "13";
+            var recipient = new OrderFulfillmentRecipient
+            {
+                DisplayName = "Bubba"
+            };
+            var orders = new List<Order>
+            {
+                new Order("alkdsf23", "i2o3jeo")
+                {
+                    CreatedAt = "2019-01-03T05:07:51Z",
+                    UpdatedAt = "2019-02-03T05:07:51Z",
+                    LineItems = new List<OrderLineItem>
+                    {
+                        new OrderLineItem(null, null, quantity)
+                        {
+                            CatalogObjectId = catalogObjectId
+                        }
+                    },
+                    Fulfillments = new List<OrderFulfillment>
+                    {
+                        new OrderFulfillment
+                        {
+                            ShipmentDetails = new OrderFulfillmentShipmentDetails
+                            {
+                                Recipient = recipient
+                            }
+                        }
+                    }
+                },
+                new Order("23ik4lkj", "aidfj23i")
+                {
+                    CreatedAt = "2019-01-03T05:07:51Z",
+                    UpdatedAt = "2019-02-03T05:07:51Z"
+                }
+            };
+            const string sku = "testSku1";
 
-			// Act
-			var result = await SquareOrdersService.CollectOrdersFromAllPagesAsync(
-				startDateUtc,
-				endDateUtc,
-				locations,
-				fakeOrdersService.MockGetOrdersWithRelatedDataMethod,
-				ordersPerPage
-			);
+            var items = new List<SquareItem>
+            {
+                new SquareItem
+                {
+                    VariationId = catalogObjectId,
+                    Sku = sku
+                }
+            };
 
-			// Assert
-			result.Should().NotBeNull();
-			fakeOrdersService.CallCounts.Count.Should().Be(3); // 3 batches of locations
-			fakeOrdersService.CallCounts[0].Should().Be(10);
-			fakeOrdersService.CallCounts[1].Should().Be(10);
-			fakeOrdersService.CallCounts[2].Should().Be(5);
-		}
-		
-		private async Task< SquareOrdersBatch > GetOrdersWithRelatedData( IEnumerable< Order > orders, IEnumerable< SquareItem > items)
-		{
-			SquareOrdersBatch result;
-			
-			if( _firstPage )
-			{
-				result = new SquareOrdersBatch
-				{
-					Orders = new List< SquareOrder >
-					{
-						orders.First().ToSvOrder( items )
-					},
-					Cursor =  "fas23afs"
-				};
-			}
-			else
-			{
-				result = new SquareOrdersBatch
-				{
-					Orders = new List< SquareOrder >
-					{
-						orders.Skip( 1 ).First().ToSvOrder( null )
-					}
-				};
-			}
+            // Act
+            var result = SquareOrdersService.CollectOrdersFromAllPagesAsync(startDateUtc, endDateUtc,
+                new List<SquareLocation>() { new SquareLocation { Id = TestLocationId } },
+                (requestBody) => GetOrdersWithRelatedData(orders, items), ordersPerPage).Result.ToList();
 
-			_firstPage = false;
+            // Assert
+            Assert.That(result.Count, Is.EqualTo(2));
+            var firstOrder = result.First();
+            Assert.That(firstOrder.OrderId, Is.EqualTo(orders.First().Id));
+            Assert.That(firstOrder.Recipient.Name, Is.EqualTo(recipient.DisplayName));
+            var firstLineItem = firstOrder.LineItems.First();
+            Assert.That(firstLineItem.Sku, Is.EqualTo(sku));
+            Assert.That(firstLineItem.Quantity, Is.EqualTo(quantity));
+            Assert.That(result.Skip(1).First().OrderId, Is.EqualTo(orders.Skip(1).First().Id));
+        }
 
-			return result;
-		}
-	}
+        [Test]
+        public async Task CollectOrdersFromAllPagesAsync_ShouldBatchLocationsCorrectly()
+        {
+            // Arrange
+            var locations = Enumerable.Range(1, 25).Select(i => new SquareLocation { Id = i.ToString() }).ToList();
+            const int ordersPerPage = 5;
+
+            var fakeOrdersService = new FakeOrdersService();
+
+            // Act
+            var result = await SquareOrdersService.CollectOrdersFromAllPagesAsync(
+                startDateUtc,
+                endDateUtc,
+                locations,
+                fakeOrdersService.MockGetOrdersWithRelatedDataMethod,
+                ordersPerPage
+            );
+
+            // Assert
+            Assert.That(result, Is.Not.Null);
+            Assert.That(fakeOrdersService.CallCounts.Count, Is.EqualTo(3)); // 3 batches of locations
+            Assert.That(fakeOrdersService.CallCounts[0], Is.EqualTo(10));
+            Assert.That(fakeOrdersService.CallCounts[1], Is.EqualTo(10));
+            Assert.That(fakeOrdersService.CallCounts[2], Is.EqualTo(5));
+        }
+
+        private async Task<SquareOrdersBatch> GetOrdersWithRelatedData(IEnumerable<Order> orders,
+            IEnumerable<SquareItem> items)
+        {
+            SquareOrdersBatch result;
+
+            if (_firstPage)
+                result = new SquareOrdersBatch
+                {
+                    Orders = new List<SquareOrder>
+                    {
+                        orders.First().ToSvOrder(items)
+                    },
+                    Cursor = "fas23afs"
+                };
+            else
+                result = new SquareOrdersBatch
+                {
+                    Orders = new List<SquareOrder>
+                    {
+                        orders.Skip(1).First().ToSvOrder(null)
+                    }
+                };
+
+            _firstPage = false;
+
+            return result;
+        }
+    }
 }

--- a/src/SquareAccessTests/OrdersServiceTests.cs
+++ b/src/SquareAccessTests/OrdersServiceTests.cs
@@ -196,28 +196,31 @@ namespace SquareAccessTests
             Assert.That(fakeOrdersService.CallCounts[2], Is.EqualTo(5));
         }
 
-        private async Task<SquareOrdersBatch> GetOrdersWithRelatedData(IEnumerable<Order> orders,
-            IEnumerable<SquareItem> items)
+        private async Task< SquareOrdersBatch > GetOrdersWithRelatedData( IEnumerable< Order > orders, IEnumerable< SquareItem > items)
         {
             SquareOrdersBatch result;
-
-            if (_firstPage)
+			
+            if( _firstPage )
+            {
                 result = new SquareOrdersBatch
                 {
-                    Orders = new List<SquareOrder>
+                    Orders = new List< SquareOrder >
                     {
-                        orders.First().ToSvOrder(items)
+                        orders.First().ToSvOrder( items )
                     },
-                    Cursor = "fas23afs"
+                    Cursor =  "fas23afs"
                 };
+            }
             else
+            {
                 result = new SquareOrdersBatch
                 {
-                    Orders = new List<SquareOrder>
+                    Orders = new List< SquareOrder >
                     {
-                        orders.Skip(1).First().ToSvOrder(null)
+                        orders.Skip( 1 ).First().ToSvOrder( null )
                     }
                 };
+            }
 
             _firstPage = false;
 

--- a/src/SquareAccessTests/OrdersServiceTests.cs
+++ b/src/SquareAccessTests/OrdersServiceTests.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NUnit.Framework;
 using Square.Connect.Model;
-using SquareAccess.Exceptions;
 using SquareAccess.Models;
 using SquareAccess.Models.Items;
 using SquareAccess.Services.Orders;
@@ -14,217 +14,158 @@ using SquareAccessTests.Mocks;
 
 namespace SquareAccessTests
 {
-    public class OrdersServiceTests : BaseTest
-    {
-        private ISquareOrdersService _ordersService;
-        private bool _firstPage;
-        private const string TestLocationId = "1GZS83Z3FC3Y3";
-        private readonly DateTime startDateUtc = DateTime.UtcNow.AddDays(-700);
-        private readonly DateTime endDateUtc = DateTime.UtcNow;
+	public class OrdersServiceTests : BaseTest
+	{
+		private ISquareOrdersService _ordersService;
+		private bool _firstPage;
+		private const string TestLocationId = "1GZS83Z3FC3Y3";
+		private readonly DateTime startDateUtc = DateTime.UtcNow.AddDays(-20);
+		private readonly DateTime endDateUtc = DateTime.UtcNow;		
 
-        [SetUp]
-        public void Init()
-        {
-            _ordersService = new SquareOrdersService(Config, Credentials, new FakeLocationsService(TestLocationId),
-                new FakeSquareItemsService());
-        }
+		[ SetUp ]
+		public void Init()
+		{
+			this._ordersService = new SquareOrdersService( this.Config, this.Credentials, new FakeLocationsService( TestLocationId ), new FakeSquareItemsService() );
+		}
 
-        [Test]
-        public void GetOrdersAsync()
-        {
-            var result = _ordersService.GetOrdersAsync(startDateUtc, endDateUtc, CancellationToken.None).Result;
+		[ Test ]
+		public void GetOrdersAsync()
+		{						
+			var result = _ordersService.GetOrdersAsync( startDateUtc, endDateUtc, CancellationToken.None ).Result;
 
-            Assert.That(result, Is.Not.Empty);
-        }
+			result.Should().NotBeEmpty();
+		}
 
-        [Test]
-        public void GetOrdersAsync_ByPage()
-        {
-            Config.OrdersPageSize = 2;
+		[ Test ]
+		public void GetOrdersAsync_ByPage()
+		{			
+			this.Config.OrdersPageSize = 2;
 
-            var result = _ordersService.GetOrdersAsync(startDateUtc, endDateUtc, CancellationToken.None).Result;
+			var result = _ordersService.GetOrdersAsync( startDateUtc, endDateUtc, CancellationToken.None ).Result;
 
-            Assert.That(result.Count(), Is.GreaterThanOrEqualTo(2));
-        }
+			result.Count().Should().BeGreaterOrEqualTo( 2 );
+		}
 
-        [Test]
-        public async Task GetOrdersAsync_ShouldThrowSquareException_WhenNoLocations()
-        {
-            // Arrange
-            var service = new SquareOrdersService(
-                Config,
-                Credentials,
-                new FakeLocationsService(() => Enumerable.Empty<SquareLocation>()),
-                new FakeSquareItemsService()
-            );
+		[ Test ]
+		public void CreateSearchOrdersBody()
+		{						
+			var locations = new List< SquareLocation >
+			{
+				new SquareLocation
+				{
+					Id = "i2o3jeo"
+				},
+				new SquareLocation
+				{
+					Id = "aidfj23i"
+				}
+			};
+			const string cursor = "23984ej2";
+			const int ordersPerPage = 10;
 
-            // Act & Assert
-            var exception = Assert.ThrowsAsync<SquareException>(async () =>
-            {
-                await service.GetOrdersAsync(startDateUtc, endDateUtc, CancellationToken.None);
-            });
+			var result = SquareOrdersService.CreateSearchOrdersBody( startDateUtc, endDateUtc, locations.AsEnumerable(), cursor, ordersPerPage );
 
-            Assert.That(
-                exception?.Message,
-                Does.Contain("No active locations. At least one is required to send SearchOrders request.")
-            );
-        }
+			result.LocationIds.Should().BeEquivalentTo( locations.Select( l => l.Id ) );
+			result.Cursor.Should().Be( cursor );
+			result.Limit.Should().Be( ordersPerPage );
+			result.Query.Filter.DateTimeFilter.UpdatedAt.StartAt.Should().Be( startDateUtc.FromUtcToRFC3339() );
+			result.Query.Filter.DateTimeFilter.UpdatedAt.EndAt.Should().Be( endDateUtc.FromUtcToRFC3339() );
+		}
 
-        [Test]
-        public void CreateSearchOrdersBody()
-        {
-            // Arrange
-            var locations = new List<SquareLocation>
-            {
-                new SquareLocation
-                {
-                    Id = "i2o3jeo"
-                },
-                new SquareLocation
-                {
-                    Id = "aidfj23i"
-                }
-            };
-            const string cursor = "23984ej2";
-            const int ordersPerPage = 10;
-
-            // Act
-            var result = SquareOrdersService.CreateSearchOrdersBody(startDateUtc, endDateUtc, locations.AsEnumerable(),
-                cursor, ordersPerPage);
-
-            // Assert
-            Assert.That(result.LocationIds, Is.EquivalentTo(locations.Select(l => l.Id)));
-            Assert.That(result.Cursor, Is.EqualTo(cursor));
-            Assert.That(result.Limit, Is.EqualTo(ordersPerPage));
-            Assert.That(result.Query.Filter.DateTimeFilter.UpdatedAt.StartAt,
-                Is.EqualTo(startDateUtc.FromUtcToRFC3339()));
-            Assert.That(result.Query.Filter.DateTimeFilter.UpdatedAt.EndAt, Is.EqualTo(endDateUtc.FromUtcToRFC3339()));
-        }
-
-        [Test]
-        public void CollectOrdersFromAllPagesAsync()
-        {
-            // Act
-            const int ordersPerPage = 2;
-            _firstPage = true;
-            const string catalogObjectId = "asldfjlkj";
-            const string quantity = "13";
-            var recipient = new OrderFulfillmentRecipient
-            {
-                DisplayName = "Bubba"
-            };
-            var orders = new List<Order>
-            {
-                new Order("alkdsf23", "i2o3jeo")
-                {
-                    CreatedAt = "2019-01-03T05:07:51Z",
-                    UpdatedAt = "2019-02-03T05:07:51Z",
-                    LineItems = new List<OrderLineItem>
-                    {
-                        new OrderLineItem(null, null, quantity)
-                        {
-                            CatalogObjectId = catalogObjectId
-                        }
-                    },
-                    Fulfillments = new List<OrderFulfillment>
-                    {
-                        new OrderFulfillment
-                        {
-                            ShipmentDetails = new OrderFulfillmentShipmentDetails
-                            {
-                                Recipient = recipient
-                            }
-                        }
-                    }
-                },
-                new Order("23ik4lkj", "aidfj23i")
-                {
-                    CreatedAt = "2019-01-03T05:07:51Z",
-                    UpdatedAt = "2019-02-03T05:07:51Z"
-                }
-            };
-            const string sku = "testSku1";
-
-            var items = new List<SquareItem>
-            {
-                new SquareItem
-                {
-                    VariationId = catalogObjectId,
-                    Sku = sku
-                }
-            };
-
-            // Act
-            var result = SquareOrdersService.CollectOrdersFromAllPagesAsync(startDateUtc, endDateUtc,
-                new List<SquareLocation>() { new SquareLocation { Id = TestLocationId } },
-                (requestBody) => GetOrdersWithRelatedData(orders, items), ordersPerPage).Result.ToList();
-
-            // Assert
-            Assert.That(result.Count, Is.EqualTo(2));
-            var firstOrder = result.First();
-            Assert.That(firstOrder.OrderId, Is.EqualTo(orders.First().Id));
-            Assert.That(firstOrder.Recipient.Name, Is.EqualTo(recipient.DisplayName));
-            var firstLineItem = firstOrder.LineItems.First();
-            Assert.That(firstLineItem.Sku, Is.EqualTo(sku));
-            Assert.That(firstLineItem.Quantity, Is.EqualTo(quantity));
-            Assert.That(result.Skip(1).First().OrderId, Is.EqualTo(orders.Skip(1).First().Id));
-        }
-
-        [Test]
-        public async Task CollectOrdersFromAllPagesAsync_ShouldBatchLocationsCorrectly()
-        {
-            // Arrange
-            var locations = Enumerable.Range(1, 25).Select(i => new SquareLocation { Id = i.ToString() }).ToList();
-            const int ordersPerPage = 5;
-
-            var fakeOrdersService = new FakeOrdersService();
-
-            // Act
-            var result = await SquareOrdersService.CollectOrdersFromAllPagesAsync(
-                startDateUtc,
-                endDateUtc,
-                locations,
-                fakeOrdersService.MockGetOrdersWithRelatedDataMethod,
-                ordersPerPage
-            );
-
-            // Assert
-            Assert.That(result, Is.Not.Null);
-            Assert.That(fakeOrdersService.CallCounts.Count, Is.EqualTo(3)); // 3 batches of locations
-            Assert.That(fakeOrdersService.CallCounts[0], Is.EqualTo(10));
-            Assert.That(fakeOrdersService.CallCounts[1], Is.EqualTo(10));
-            Assert.That(fakeOrdersService.CallCounts[2], Is.EqualTo(5));
-        }
-
-        private async Task< SquareOrdersBatch > GetOrdersWithRelatedData( IEnumerable< Order > orders, IEnumerable< SquareItem > items)
-        {
-            SquareOrdersBatch result;
+		[ Test ]
+		public void CollectOrdersFromAllPagesAsync()
+		{			
+			const int ordersPerPage = 2;
+			_firstPage = true;
+			const string catalogObjectId = "asldfjlkj";
+			const string quantity = "13";
+			var recipient = new OrderFulfillmentRecipient
+			{
+				DisplayName = "Bubba"
+			};
+			var orders = new List< Order >
+			{
+				new Order( "alkdsf23", "i2o3jeo" )
+				{
+					CreatedAt = "2019-01-03T05:07:51Z",
+					UpdatedAt = "2019-02-03T05:07:51Z",
+					LineItems = new List< OrderLineItem >
+					{
+						new OrderLineItem( null, null, Quantity: quantity )
+						{
+							CatalogObjectId = catalogObjectId,
+						}
+					},
+					Fulfillments = new List< OrderFulfillment >
+					{
+						new OrderFulfillment
+						{
+							ShipmentDetails = new OrderFulfillmentShipmentDetails
+							{
+								Recipient = recipient
+							}
+						}
+					}
+				},
+				new Order( "23ik4lkj", "aidfj23i" )
+				{
+					CreatedAt = "2019-01-03T05:07:51Z",
+					UpdatedAt = "2019-02-03T05:07:51Z"
+				}
+			};
+			const string sku = "testSku1";
 			
-            if( _firstPage )
-            {
-                result = new SquareOrdersBatch
-                {
-                    Orders = new List< SquareOrder >
-                    {
-                        orders.First().ToSvOrder( items )
-                    },
-                    Cursor =  "fas23afs"
-                };
-            }
-            else
-            {
-                result = new SquareOrdersBatch
-                {
-                    Orders = new List< SquareOrder >
-                    {
-                        orders.Skip( 1 ).First().ToSvOrder( null )
-                    }
-                };
-            }
+			var items = new List< SquareItem >
+			{
+				new SquareItem
+				{
+					VariationId = catalogObjectId,
+					Sku = sku
+				}
+			};
 
-            _firstPage = false;
+			var result = SquareOrdersService.CollectOrdersFromAllPagesAsync( startDateUtc, endDateUtc, new List< SquareLocation >(), 
+				( requestBody ) => GetOrdersWithRelatedData( orders, items ), ordersPerPage ).Result.ToList();
 
-            return result;
-        }
-    }
+			result.Count.Should().Be( 2 );
+			var firstOrder = result.First();
+			firstOrder.OrderId.Should().BeEquivalentTo( orders.First().Id );
+			firstOrder.Recipient.Name.Should().BeEquivalentTo( recipient.DisplayName );
+			var firstLineItem = firstOrder.LineItems.First();
+			firstLineItem.Sku.Should().Be( sku );
+			firstLineItem.Quantity.Should().Be( quantity );
+			result.Skip( 1 ).First().OrderId.Should().BeEquivalentTo( orders.Skip( 1 ).First().Id );
+		}
+
+		private async Task< SquareOrdersBatch > GetOrdersWithRelatedData( IEnumerable< Order > orders, IEnumerable< SquareItem > items)
+		{
+			SquareOrdersBatch result;
+			
+			if( _firstPage )
+			{
+				result = new SquareOrdersBatch
+				{
+					Orders = new List< SquareOrder >
+					{
+						orders.First().ToSvOrder( items )
+					},
+					Cursor =  "fas23afs"
+				};
+			}
+			else
+			{
+				result = new SquareOrdersBatch
+				{
+					Orders = new List< SquareOrder >
+					{
+						orders.Skip( 1 ).First().ToSvOrder( null )
+					}
+				};
+			}
+
+			_firstPage = false;
+
+			return result;
+		}
+	}
 }

--- a/src/SquareAccessTests/OrdersServiceTests.cs
+++ b/src/SquareAccessTests/OrdersServiceTests.cs
@@ -48,7 +48,7 @@ namespace SquareAccessTests
         }
 
         [Test]
-        public async Task GetOrdersAsync_ShouldThrowException_WhenNoLocations()
+        public async Task GetOrdersAsync_ShouldThrowSquareException_WhenNoLocations()
         {
             // Arrange
             var service = new SquareOrdersService(

--- a/src/SquareAccessTests/SquareAccessTests.csproj
+++ b/src/SquareAccessTests/SquareAccessTests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="LocationMapperTests.cs" />
     <Compile Include="Mocks\FakeLocationsService.cs" />
     <Compile Include="LocationsServiceTests.cs" />
+    <Compile Include="Mocks\FakeOrdersService.cs" />
     <Compile Include="Mocks\FakeSquareItemsService.cs" />
     <Compile Include="OrderMapperTests.cs" />
     <Compile Include="OrderRecipientMapperTests.cs" />


### PR DESCRIPTION
# Description

Tickets: [PBL-9319] <!-- Replace with appropriate tickets. Some automation depend on this section, don't remove -->

Summary: Updated the Square’s Search Orders request to request orders for up to 10 locations at a time.

## Background
We were requesting orders for all locations at once, while the limit is 10 locations per request.

## About these changes
- Split locations into batches of 10 and wrapped existing code in a foreach (var locationBatch in locationBatches) loop to send separate Search Orders requests for batches of up to 10 locations each.
https://github.com/skuvault-integrations/squareAccess/pull/21/files#diff-8a94857dba38f608be7f4cff1c5a340a4b8c086c11f8a0e8fc60595837ca5675R99
- Added "no locations" check to return early. At least one location is required.
https://github.com/skuvault-integrations/squareAccess/pull/21/files#diff-8a94857dba38f608be7f4cff1c5a340a4b8c086c11f8a0e8fc60595837ca5675R65
- Added tests GetOrdersAsync_ShouldThrowSquareException_WhenNoLocations() and CollectOrdersFromAllPagesAsync_ShouldBatchLocationsCorrectly()
- Added new MockGetOrdersWithRelatedDataMethod() into a new file FakeOrdersService.cs similar to FakeLocationsService and FakeSquareItemsService with mocks.


# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [ ] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [x] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [ ] Acceptance criteria are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[PBL-9319]: https://linnworks.atlassian.net/browse/PBL-9319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ