### PR TITLE
guard/PBL-9319-update-square-search-orders-2

### DIFF
--- a/src/SquareAccess/Services/Orders/SquareOrdersService.cs
+++ b/src/SquareAccess/Services/Orders/SquareOrdersService.cs
@@ -172,7 +172,7 @@ namespace SquareAccess.Services.Orders
 				throw squareException;
 			}
 
-			var response = await base.ThrottleRequest( SquareEndPoint.SearchCatalogUrl, requestBody.ToJson(), mark, ( _ ) =>
+			var response = await base.ThrottleRequest( SquareEndPoint.OrdersSearchUrl, requestBody.ToJson(), mark, ( _ ) =>
 			{
 				return  _ordersApi.SearchOrdersAsync( requestBody );
 			}, token ).ConfigureAwait( false );

--- a/src/SquareAccess/SquareAccess.csproj
+++ b/src/SquareAccess/SquareAccess.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
     <Authors>SkuVault</Authors>
     <Company>SkuVault</Company>
-    <Version>1.1.13.0-alpha.2</Version>
+    <Version>1.1.13.0-alpha.3</Version>
     <Description>SquareAccess webservices API wrapper</Description>
     <Copyright>SkuVault © 2019-2025</Copyright>
     <PackageLicenseUrl></PackageLicenseUrl>


### PR DESCRIPTION
# Description

Tickets: [PBL-9319] <!-- Replace with appropriate tickets. Some automation depend on this section, don't remove -->

Summary: corrected copy/paste mishap to use
## Background
Throttling of SquareEndPoint.SearchCatalogUrl in the SearchOrdersAsync method appears to be an oversight. The correct endpoint for searching orders should be SquareEndPoint.OrdersSearchUrl

## About these changes
-corrected url
-increased version

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [ ] I have updated all relevant configuration
- [ ] Followed [development conventions][1] to the best of my ability
- [ ] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [ ] Performed a self-review of my own code
- [ ] Acceptance criteria are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [ ] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions
